### PR TITLE
fix(cuda_black_board_publisher): publish ros msg when intra cuda subsriber does not exists

### DIFF
--- a/src/cuda_blackboard_publisher.cpp
+++ b/src/cuda_blackboard_publisher.cpp
@@ -54,8 +54,8 @@ void CudaBlackboardPublisher<T>::publish(std::unique_ptr<const T> cuda_msg_ptr)
 
   auto & blackboard = CudaBlackboard<T>::getInstance();
 
-  // If data is loaded from blackboard, the data which will be published as ros msg is stored in
-  // blackboard_data
+  // When data is retrieved from the blackboard, it is stored in blackboard_data to be published as
+  // a ROS message.
   std::shared_ptr<const T> blackboard_data = nullptr;
 
   // When we want to publish cuda data, we instead use the blackboard
@@ -66,8 +66,7 @@ void CudaBlackboardPublisher<T>::publish(std::unique_ptr<const T> cuda_msg_ptr)
                                                           // subscribers
 
     if (tickets == 0 && !publish_ros_msg) {
-      // If there is no intra process blackboard subscription and ros msg is not published,
-      // abort this function
+      // Return early if there are no intra-process subscribers and no ROS subscribers
       return;
     }
 


### PR DESCRIPTION
## PR Type

- Bug Fix

## Related Links

[TIER IV INTERNAL TICKET](https://tier4.atlassian.net/browse/RT0-37147)

## Description

In the current implementation, if the negotiated_subscriber is not using intra_process, the `compatible_pub_` does not publish even if there is a ROS compatible subscriber.
This PR modifies the behavior so that `compatible_pub_` will publish in such cases as well.


> [!NOTE]
>  I know having the negotiated_subscriber and negotiated_publisher in different processes is not an expected use case.
> But, regardless of that, I believe it should publish properly when there is a ROS subscriber.

## Review Procedure

I verified that the change is correct by running the publisher and subscriber in separate processes and checking the intermediate topic using ros2 topic echo.

### before
```bash
# Run publisher/subsriber in separated process
ros2 run cuda_blackboard cuda_blackboard_publisher_node --ros-args -p image_path:=$HOME/image.png
ros2 run cuda_blackboard cuda_blackboard_subscriber_node

# Check `/image_raw` subscrib-ility
ros2 topic echo /image_raw --no-arr  # This does NOT print anything
```

### after
```bash
# run publisher/subsriber in separated process
ros2 run cuda_blackboard cuda_blackboard_publisher_node --ros-args -p image_path:=$HOME/image.png
ros2 run cuda_blackboard cuda_blackboard_subscriber_node

# Check `/image_raw` subscrib-ility
ros2 topic echo /image_raw --no-arr  # This print something
```


## Remarks


## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
