### PR TITLE
fix: compatible subscriber was not publisher in certain situations

### DIFF
--- a/src/cuda_blackboard_publisher.cpp
+++ b/src/cuda_blackboard_publisher.cpp
@@ -49,22 +49,19 @@ void CudaBlackboardPublisher<T>::publish(std::unique_ptr<const T> cuda_msg_ptr)
     negotiated_pub_->type_was_negotiated<NegotiationStruct<typename T::ros_type>>() &&
     (compatible_pub_->get_subscription_count() > 0 ||
      compatible_pub_->get_intra_process_subscription_count() > 0);
+
+  // tickets are only given to intra process subcribers
+  auto & publisher = map.at(key_name).publisher;
+  std::size_t tickets =
+    publisher != nullptr ? publisher->get_intra_process_subscription_count() : 0;
+
   bool publish_blackboard_msg =
-    negotiated_pub_->type_was_negotiated<NegotiationStruct<T>>() && map.count(key_name) > 0;
+    negotiated_pub_->type_was_negotiated<NegotiationStruct<T>>() && tickets > 0;
 
   auto & blackboard = CudaBlackboard<T>::getInstance();
 
   // When we want to publish cuda data, we instead use the blackboard
   if (publish_blackboard_msg) {
-    auto & publisher = map.at(key_name).publisher;
-    std::size_t tickets =
-      publisher->get_intra_process_subscription_count();  // tickets are only given to intra process
-                                                          // subscribers
-
-    if (tickets == 0) {
-      return;
-    }
-
     if (publish_ros_msg) {
       tickets++;
     }

--- a/src/cuda_blackboard_publisher.cpp
+++ b/src/cuda_blackboard_publisher.cpp
@@ -50,7 +50,7 @@ void CudaBlackboardPublisher<T>::publish(std::unique_ptr<const T> cuda_msg_ptr)
     (compatible_pub_->get_subscription_count() > 0 ||
      compatible_pub_->get_intra_process_subscription_count() > 0);
 
-  // tickets are only given to intra process subcribers
+  // tickets are only given to intra process subscribers
   auto & publisher = map.at(key_name).publisher;
   std::size_t tickets =
     publisher != nullptr ? publisher->get_intra_process_subscription_count() : 0;

--- a/src/cuda_blackboard_publisher_node.cpp
+++ b/src/cuda_blackboard_publisher_node.cpp
@@ -50,6 +50,7 @@ public:
 
     auto publish_message = [this]() -> void {
       auto cuda_image_ptr = std::make_unique<CudaImage>(ros_image_);
+      cuda_image_ptr->header.stamp = this->now();
       RCLCPP_INFO(this->get_logger(), "Publishing message n=%d", count_++);
       pub_->publish(std::move(cuda_image_ptr));
     };


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->

- Bug Fix

## Related Links

<!-- Please write related links to GitHub/Jira/Slack/etc. -->

## Description

Simplified version of the issue reported in https://github.com/autowarefoundation/cuda_blackboard/pull/10

When out of container compatible subscribers were present, no tickets were generated but it was flagged as a target for the negotiated publisher, causing no compatible topics to be published. This PR solves that

## Review Procedure

Same as https://github.com/autowarefoundation/cuda_blackboard/pull/10

## Remarks

<!-- Write remarks as you like if you need them. -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Assign PR to reviewer

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] (Optional) Unit tests have been written for new behavior
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR**: Required to pass before the merge.
