### PR TITLE
fix: cv_bridge include jazzy support

### DIFF
--- a/src/cuda_blackboard_publisher_node.cpp
+++ b/src/cuda_blackboard_publisher_node.cpp
@@ -10,7 +10,11 @@
 
 #include <sensor_msgs/msg/image.hpp>
 
-#include <cv_bridge/cv_bridge.h>
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>  // for ROS 2 Jazzy or newer
+#else
+#include <cv_bridge/cv_bridge.h>  // for ROS 2 Humble or older
+#endif
 
 #include <chrono>
 #include <memory>


### PR DESCRIPTION
- Part of: https://github.com/autowarefoundation/autoware/issues/6695
- Similar to: https://github.com/autowarefoundation/autoware_universe/pull/11873

Updated the header includes to support both humble and jazzy.