### PR TITLE
feat: stream-aware publish/subscribe (backwards-compatible)

### DIFF
--- a/include/cuda_blackboard/cuda_blackboard.hpp
+++ b/include/cuda_blackboard/cuda_blackboard.hpp
@@ -4,6 +4,8 @@
 #include "cuda_blackboard/cuda_image.hpp"
 #include "cuda_blackboard/cuda_pointcloud2.hpp"
 
+#include <cuda_runtime_api.h>
+
 #include <memory>
 #include <mutex>
 #include <random>
@@ -19,14 +21,35 @@ class CudaBlackboardDataWrapper
 public:
   CudaBlackboardDataWrapper(
     std::shared_ptr<const T> data_ptr, const std::string producer_name, uint64_t instance_id,
-    std::size_t tickets)
-  : data_ptr_(data_ptr), producer_name_(producer_name), instance_id_(instance_id), tickets_(tickets)
+    std::size_t tickets, cudaEvent_t ready_event = nullptr)
+  : data_ptr_(data_ptr),
+    producer_name_(producer_name),
+    instance_id_(instance_id),
+    tickets_(tickets),
+    ready_event_(ready_event)
   {
   }
+
+  CudaBlackboardDataWrapper(const CudaBlackboardDataWrapper &) = delete;
+  CudaBlackboardDataWrapper & operator=(const CudaBlackboardDataWrapper &) = delete;
+
+  ~CudaBlackboardDataWrapper()
+  {
+    // Owns the "ready" event the publisher recorded on its stream. The wrapper
+    // is kept alive (via aliasing shared_ptrs handed out by queryData) until
+    // every subscriber has queued its wait on the event, so destroying it here
+    // is safe. The buffer in data_ptr_ is released right after, on the consumer
+    // stream when one was set on its deleter.
+    if (ready_event_ != nullptr) {
+      cudaEventDestroy(ready_event_);
+    }
+  }
+
   std::shared_ptr<const T> data_ptr_;
   std::string producer_name_;
   uint64_t instance_id_;
   std::size_t tickets_;
+  cudaEvent_t ready_event_{nullptr};
 };
 
 template <typename T>
@@ -40,9 +63,12 @@ public:
   static CudaBlackboard & getInstance();
 
   uint64_t registerData(
-    const std::string & producer_name, std::unique_ptr<const T> value, std::size_t tickets);
+    const std::string & producer_name, std::unique_ptr<const T> value, std::size_t tickets,
+    cudaEvent_t ready_event = nullptr);
   std::shared_ptr<const T> queryData(const std::string & producer_name);
-  std::shared_ptr<const T> queryData(uint64_t instance_id);
+  // When ready_event_out is non-null, it receives the publisher's "ready" event
+  // for this instance so the subscriber can order its stream after the fill.
+  std::shared_ptr<const T> queryData(uint64_t instance_id, cudaEvent_t * ready_event_out = nullptr);
 
 private:
   std::unordered_map<std::string, CudaBlackboardDataWrapperPtr> producer_to_data_map_;

--- a/include/cuda_blackboard/cuda_blackboard_publisher.hpp
+++ b/include/cuda_blackboard/cuda_blackboard_publisher.hpp
@@ -6,6 +6,8 @@
 #include <negotiated/negotiated_publisher.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <cuda_runtime_api.h>
+
 #include <memory>
 #include <string>
 #include <utility>
@@ -20,10 +22,21 @@ public:
   CudaBlackboardPublisher(rclcpp::Node & node, const std::string & topic_name);
   void publish(std::unique_ptr<const T> msg);
 
+  // Stream-ordered publish: `stream` is the stream the message buffer was
+  // allocated and filled on. The buffer is not host-synchronized before
+  // publishing; consumers using the stream-aware subscriber are ordered after
+  // the fill via CUDA events. The buffer must outlive every subscriber's use,
+  // which is guaranteed because the stream (owned by the producing node)
+  // outlives the messages it produces.
+  void publish(std::unique_ptr<const T> msg, cudaStream_t stream);
+
   std::size_t get_subscription_count() const;
   std::size_t get_intra_process_subscription_count() const;
 
 private:
+  // Shared implementation. `stream` is nullptr for the legacy synchronous path.
+  void publishImpl(std::unique_ptr<const T> msg, cudaStream_t stream);
+
   rclcpp::Node & node_;
   std::shared_ptr<negotiated::NegotiatedPublisher> negotiated_pub_;
   typename rclcpp::Publisher<typename T::ros_type>::SharedPtr compatible_pub_;

--- a/include/cuda_blackboard/cuda_blackboard_subscriber.hpp
+++ b/include/cuda_blackboard/cuda_blackboard_subscriber.hpp
@@ -7,6 +7,8 @@
 
 #include <std_msgs/msg/u_int64.hpp>
 
+#include <cuda_runtime_api.h>
+
 #include <memory>
 
 namespace cuda_blackboard
@@ -24,7 +26,18 @@ public:
     rclcpp::Node & node, const std::string & topic_name,
     std::function<void(std::shared_ptr<const T>)> callback);
 
+  // Stream-aware subscriber: `stream` is the stream this node uses to read the
+  // received buffers. Before the user callback runs, the stream is ordered
+  // after the producer's fill; after it returns, a dependency is registered so
+  // the buffer's async free waits for this stream's queued reads. The stream
+  // must outlive this subscriber and every message delivered through it.
+  CudaBlackboardSubscriber(
+    rclcpp::Node & node, const std::string & topic_name,
+    std::function<void(std::shared_ptr<const T>)> callback, cudaStream_t stream);
+
 private:
+  void initialize(const std::string & topic_name);
+
   void instanceIdCallback(const std_msgs::msg::UInt64 & instance_id_msg);
 
   void compatibleCallback(const std::shared_ptr<const typename T::ros_type> & ros_msg_ptr);
@@ -32,6 +45,7 @@ private:
   std::function<void(std::shared_ptr<const T> cuda_msg)> callback_{};
 
   rclcpp::Node & node_;
+  cudaStream_t stream_{nullptr};
   std::shared_ptr<negotiated::NegotiatedSubscription> negotiated_sub_;
   typename rclcpp::Subscription<typename T::ros_type>::SharedPtr compatible_sub_;
 };

--- a/include/cuda_blackboard/cuda_unique_ptr.hpp
+++ b/include/cuda_blackboard/cuda_unique_ptr.hpp
@@ -45,9 +45,47 @@ void cuda_check_error(const ::cudaError_t e, F && f, N && n)
   }
 }
 
+// Deleter for device memory. By default it frees synchronously with cudaFree
+// (which implicitly synchronizes the whole device). When constructed with a
+// stream it instead frees with cudaFreeAsync on that stream, so the free is
+// ordered on the stream rather than stalling the device.
+//
+// The deleter keeps the same type regardless of mode, so CudaUniquePtr<T> (and
+// therefore every member that uses it, e.g. CudaPointCloud2::data) is unchanged
+// and existing code remains source-compatible.
+//
+// The free stream can be re-targeted after construction with set_stream(). This
+// is what lets a buffer allocated on the producer stream be freed on a
+// consumer's stream instead (ordering the free after that consumer's reads).
+// set_stream() is const and the stream is mutable on purpose: the free stream
+// is resource-reclamation plumbing, not part of the buffer's value, so it is
+// settable even through a unique_ptr owned by a shared_ptr<const T>.
 struct CudaDeleter
 {
-  void operator()(void * p) const { CUDA_BLACKBOARD_CHECK_CUDA_ERROR(::cudaFree(p)); }
+  CudaDeleter() = default;
+  explicit CudaDeleter(cudaStream_t stream) : stream_(stream), async_(true) {}
+
+  void operator()(void * p) const
+  {
+    if (async_) {
+      CUDA_BLACKBOARD_CHECK_CUDA_ERROR(::cudaFreeAsync(p, stream_));
+    } else {
+      CUDA_BLACKBOARD_CHECK_CUDA_ERROR(::cudaFree(p));
+    }
+  }
+
+  // Re-target the stream the buffer will be freed on. No effect for a
+  // synchronously allocated buffer (one not created via the stream-aware
+  // make_unique), which must keep its cudaFree path.
+  void set_stream(cudaStream_t stream) const
+  {
+    if (async_) {
+      stream_ = stream;
+    }
+  }
+
+  mutable cudaStream_t stream_{nullptr};
+  bool async_{false};
 };
 template <typename T>
 using CudaUniquePtr = std::unique_ptr<T, CudaDeleter>;
@@ -68,6 +106,31 @@ CudaUniquePtr<T> make_unique()
   T * p;
   CUDA_BLACKBOARD_CHECK_CUDA_ERROR(::cudaMalloc(reinterpret_cast<void **>(&p), sizeof(T)));
   return CudaUniquePtr<T>{p};
+}
+
+// Stream-ordered allocations: the memory is allocated with cudaMallocAsync on
+// the given stream and the returned pointer carries a deleter that frees it
+// with cudaFreeAsync on the same stream. Requires CUDA >= 11.2 with memory-pool
+// support (cudaDevAttrMemoryPoolsSupported).
+template <typename T>
+typename std::enable_if_t<std::is_array<T>::value, CudaUniquePtr<T>> make_unique(
+  const std::size_t n, cudaStream_t stream)
+{
+  using U = typename std::remove_extent_t<T>;
+  U * p;
+  CUDA_BLACKBOARD_CHECK_CUDA_ERROR(
+    ::cudaMallocAsync(reinterpret_cast<void **>(&p), sizeof(U) * n, stream));
+  return CudaUniquePtr<T>{p, CudaDeleter{stream}};
+}
+
+template <typename T>
+typename std::enable_if_t<!std::is_array<T>::value, CudaUniquePtr<T>> make_unique(
+  cudaStream_t stream)
+{
+  T * p;
+  CUDA_BLACKBOARD_CHECK_CUDA_ERROR(
+    ::cudaMallocAsync(reinterpret_cast<void **>(&p), sizeof(T), stream));
+  return CudaUniquePtr<T>{p, CudaDeleter{stream}};
 }
 
 struct HostDeleter

--- a/src/cuda_blackboard.cpp
+++ b/src/cuda_blackboard.cpp
@@ -17,7 +17,8 @@ CudaBlackboard<T> & CudaBlackboard<T>::getInstance()
 
 template <typename T>
 uint64_t CudaBlackboard<T>::registerData(
-  const std::string & producer_name, std::unique_ptr<const T> data, std::size_t tickets)
+  const std::string & producer_name, std::unique_ptr<const T> data, std::size_t tickets,
+  cudaEvent_t ready_event)
 {
   std::lock_guard<std::mutex> lock(mutex_);
 
@@ -31,7 +32,7 @@ uint64_t CudaBlackboard<T>::registerData(
 
   std::shared_ptr<CudaBlackboardDataWrapper<T>> data_wrapper =
     std::make_shared<CudaBlackboardDataWrapper<T>>(
-      std::move(data), producer_name, instance_id, tickets);
+      std::move(data), producer_name, instance_id, tickets, ready_event);
 
   if (producer_to_data_map_.count(producer_name) > 0) {
     RCLCPP_WARN_STREAM(
@@ -58,17 +59,21 @@ std::shared_ptr<const T> CudaBlackboard<T>::queryData(const std::string & produc
   auto it = producer_to_data_map_.find(producer_name);
 
   if (it != producer_to_data_map_.end()) {
-    it->second->tickets_--;
-    auto data = it->second->data_ptr_;
+    auto wrapper = it->second;  // keep the wrapper alive across the map erase below
+    wrapper->tickets_--;
+
+    // Aliasing shared_ptr: returns the buffer but co-owns the wrapper, so the
+    // wrapper (and its ready event) outlives every consumer that holds the data.
+    std::shared_ptr<const T> data(wrapper, wrapper->data_ptr_.get());
 
     RCLCPP_DEBUG_STREAM(
       rclcpp::get_logger("CudaBlackboard"),
-      "Producer " << producer_name << " has " << it->second->tickets_ << " tickets left");
+      "Producer " << producer_name << " has " << wrapper->tickets_ << " tickets left");
 
-    if (it->second->tickets_ == 0) {
+    if (wrapper->tickets_ == 0) {
       RCLCPP_DEBUG_STREAM(
         rclcpp::get_logger("CudaBlackboard"), "Removing data from producer " << producer_name);
-      instance_id_to_data_map_.erase(it->second->instance_id_);
+      instance_id_to_data_map_.erase(wrapper->instance_id_);
       producer_to_data_map_.erase(it);
     }
 
@@ -78,23 +83,32 @@ std::shared_ptr<const T> CudaBlackboard<T>::queryData(const std::string & produc
 }
 
 template <typename T>
-std::shared_ptr<const T> CudaBlackboard<T>::queryData(uint64_t instance_id)
+std::shared_ptr<const T> CudaBlackboard<T>::queryData(
+  uint64_t instance_id, cudaEvent_t * ready_event_out)
 {
   std::lock_guard<std::mutex> lock(mutex_);
   auto it = instance_id_to_data_map_.find(instance_id);
 
   if (it != instance_id_to_data_map_.end()) {
-    it->second->tickets_--;
-    std::shared_ptr<const T> data = it->second->data_ptr_;
+    auto wrapper = it->second;  // keep the wrapper alive across the map erase below
+    wrapper->tickets_--;
+
+    if (ready_event_out != nullptr) {
+      *ready_event_out = wrapper->ready_event_;
+    }
+
+    // Aliasing shared_ptr: returns the buffer but co-owns the wrapper, so the
+    // wrapper (and its ready event) outlives every consumer that holds the data.
+    std::shared_ptr<const T> data(wrapper, wrapper->data_ptr_.get());
 
     RCLCPP_DEBUG_STREAM(
       rclcpp::get_logger("CudaBlackboard"),
-      "Instance " << instance_id << " has " << it->second->tickets_ << " tickets left");
+      "Instance " << instance_id << " has " << wrapper->tickets_ << " tickets left");
 
-    if (it->second->tickets_ == 0) {
+    if (wrapper->tickets_ == 0) {
       RCLCPP_DEBUG_STREAM(
         rclcpp::get_logger("CudaBlackboard"), "Removing data from instance " << instance_id);
-      producer_to_data_map_.erase(it->second->producer_name_);
+      producer_to_data_map_.erase(wrapper->producer_name_);
       instance_id_to_data_map_.erase(it);
     }
 

--- a/src/cuda_blackboard_publisher.cpp
+++ b/src/cuda_blackboard_publisher.cpp
@@ -41,8 +41,7 @@ void CudaBlackboardPublisher<T>::publish(std::unique_ptr<const T> cuda_msg_ptr)
 }
 
 template <typename T>
-void CudaBlackboardPublisher<T>::publish(
-  std::unique_ptr<const T> cuda_msg_ptr, cudaStream_t stream)
+void CudaBlackboardPublisher<T>::publish(std::unique_ptr<const T> cuda_msg_ptr, cudaStream_t stream)
 {
   publishImpl(std::move(cuda_msg_ptr), stream);
 }

--- a/src/cuda_blackboard_publisher.cpp
+++ b/src/cuda_blackboard_publisher.cpp
@@ -37,6 +37,20 @@ CudaBlackboardPublisher<T>::CudaBlackboardPublisher(
 template <typename T>
 void CudaBlackboardPublisher<T>::publish(std::unique_ptr<const T> cuda_msg_ptr)
 {
+  publishImpl(std::move(cuda_msg_ptr), nullptr);
+}
+
+template <typename T>
+void CudaBlackboardPublisher<T>::publish(
+  std::unique_ptr<const T> cuda_msg_ptr, cudaStream_t stream)
+{
+  publishImpl(std::move(cuda_msg_ptr), stream);
+}
+
+template <typename T>
+void CudaBlackboardPublisher<T>::publishImpl(
+  std::unique_ptr<const T> cuda_msg_ptr, cudaStream_t stream)
+{
   auto & map = negotiated_pub_->get_supported_types();
 
   using ROSMessageType = typename NegotiationStruct<T>::MsgT;
@@ -66,9 +80,20 @@ void CudaBlackboardPublisher<T>::publish(std::unique_ptr<const T> cuda_msg_ptr)
       tickets++;
     }
 
+    // Record (on the producer stream) that the buffer is filled. Subscribers
+    // wait on this event from their own stream, so no host synchronization is
+    // needed to order the consumer reads after the producer's fill. The event
+    // is owned by the blackboard entry and destroyed when the buffer is freed.
+    cudaEvent_t ready_event = nullptr;
+    if (stream != nullptr) {
+      CUDA_BLACKBOARD_CHECK_CUDA_ERROR(
+        ::cudaEventCreateWithFlags(&ready_event, cudaEventDisableTiming));
+      CUDA_BLACKBOARD_CHECK_CUDA_ERROR(::cudaEventRecord(ready_event, stream));
+    }
+
     instance_id = blackboard.registerData(
       std::string(node_.get_fully_qualified_name()) + "_" + publisher->get_topic_name(),
-      std::move(cuda_msg_ptr), tickets);
+      std::move(cuda_msg_ptr), tickets, ready_event);
 
     RCLCPP_DEBUG(
       node_.get_logger(), "Publishing instance id %lu with %ld tickets", instance_id, tickets);
@@ -77,6 +102,11 @@ void CudaBlackboardPublisher<T>::publish(std::unique_ptr<const T> cuda_msg_ptr)
     instance_msg.data = static_cast<uint64_t>(instance_id);
     negotiated_pub_->publish<NegotiationStruct<T>>(instance_msg);
   } else if (publish_ros_msg) {
+    // The (synchronous) type adaptation copies the buffer device-to-host on the
+    // default stream, so ensure the producer's async fill has completed first.
+    if (stream != nullptr) {
+      CUDA_BLACKBOARD_CHECK_CUDA_ERROR(::cudaStreamSynchronize(stream));
+    }
     auto ros_msg_ptr = std::make_unique<typename T::ros_type>();
     rclcpp::TypeAdapter<T>::convert_to_ros_message(*cuda_msg_ptr, *ros_msg_ptr);
 
@@ -85,6 +115,9 @@ void CudaBlackboardPublisher<T>::publish(std::unique_ptr<const T> cuda_msg_ptr)
 
   // When we want to publish ros data, we need to use type adaptation
   if (publish_blackboard_msg && publish_ros_msg) {
+    if (stream != nullptr) {
+      CUDA_BLACKBOARD_CHECK_CUDA_ERROR(::cudaStreamSynchronize(stream));
+    }
     auto data = blackboard.queryData(instance_id);
     auto ros_msg_ptr = std::make_unique<typename T::ros_type>();
     rclcpp::TypeAdapter<T>::convert_to_ros_message(*data, *ros_msg_ptr);

--- a/src/cuda_blackboard_subscriber.cpp
+++ b/src/cuda_blackboard_subscriber.cpp
@@ -15,31 +15,8 @@ CudaBlackboardSubscriber<T>::CudaBlackboardSubscriber(
   std::function<void(std::shared_ptr<const T>)> callback)
 : node_(node)
 {
-  using std::placeholders::_1;
-
-  negotiated::NegotiatedSubscriptionOptions negotiation_options;
-  negotiation_options.disconnect_on_negotiation_failure = false;
-
   callback_ = callback;
-  negotiated_sub_ = std::make_shared<negotiated::NegotiatedSubscription>(
-    node, topic_name + "/cuda", negotiation_options);
-
-  rclcpp::SubscriptionOptions sub_options;
-  sub_options.use_intra_process_comm = rclcpp::IntraProcessSetting::Enable;
-
-  negotiated_sub_->add_supported_callback<NegotiationStruct<T>>(
-    1.0, rclcpp::QoS(1), std::bind(&CudaBlackboardSubscriber<T>::instanceIdCallback, this, _1),
-    sub_options);
-
-  std::string ros_type_name = NegotiationStruct<typename T::ros_type>::supported_type_name;
-
-  compatible_sub_ = node.create_subscription<typename T::ros_type>(
-    topic_name, rclcpp::SensorDataQoS(),
-    std::bind(&CudaBlackboardSubscriber<T>::compatibleCallback, this, _1), sub_options);
-
-  negotiated_sub_->add_compatible_subscription(compatible_sub_, ros_type_name, 0.1);
-
-  negotiated_sub_->start();
+  initialize(topic_name);
 }
 
 template <typename T>
@@ -48,14 +25,30 @@ CudaBlackboardSubscriber<T>::CudaBlackboardSubscriber(
   std::function<void(std::shared_ptr<const T>)> callback)
 : node_(node)
 {
+  callback_ = callback;
+  initialize(topic_name);
+}
+
+template <typename T>
+CudaBlackboardSubscriber<T>::CudaBlackboardSubscriber(
+  rclcpp::Node & node, const std::string & topic_name,
+  std::function<void(std::shared_ptr<const T>)> callback, cudaStream_t stream)
+: node_(node), stream_(stream)
+{
+  callback_ = callback;
+  initialize(topic_name);
+}
+
+template <typename T>
+void CudaBlackboardSubscriber<T>::initialize(const std::string & topic_name)
+{
   using std::placeholders::_1;
 
   negotiated::NegotiatedSubscriptionOptions negotiation_options;
   negotiation_options.disconnect_on_negotiation_failure = false;
 
-  callback_ = callback;
   negotiated_sub_ = std::make_shared<negotiated::NegotiatedSubscription>(
-    node, topic_name + "/cuda", negotiation_options);
+    node_, topic_name + "/cuda", negotiation_options);
 
   rclcpp::SubscriptionOptions sub_options;
   sub_options.use_intra_process_comm = rclcpp::IntraProcessSetting::Enable;
@@ -66,7 +59,7 @@ CudaBlackboardSubscriber<T>::CudaBlackboardSubscriber(
 
   std::string ros_type_name = NegotiationStruct<typename T::ros_type>::supported_type_name;
 
-  compatible_sub_ = node.create_subscription<typename T::ros_type>(
+  compatible_sub_ = node_.create_subscription<typename T::ros_type>(
     topic_name, rclcpp::SensorDataQoS(),
     std::bind(&CudaBlackboardSubscriber<T>::compatibleCallback, this, _1), sub_options);
 
@@ -90,9 +83,25 @@ void CudaBlackboardSubscriber<T>::instanceIdCallback(const std_msgs::msg::UInt64
   }
 
   auto & blackboard = CudaBlackboard<T>::getInstance();
-  auto data = blackboard.queryData(instance_id_msg.data);
+  cudaEvent_t ready_event = nullptr;
+  auto data = blackboard.queryData(instance_id_msg.data, &ready_event);
   if (data) {
+    // Order this node's stream after the producer's fill (no host stall), then
+    // run the user callback, which queues its reads on stream_.
+    if (stream_ != nullptr && ready_event != nullptr) {
+      CUDA_BLACKBOARD_CHECK_CUDA_ERROR(::cudaStreamWaitEvent(stream_, ready_event, 0));
+    }
+
     callback_(data);
+
+    // Free the buffer on this subscriber's stream: point its deleter at stream_
+    // so the eventual cudaFreeAsync is queued after the reads above (same
+    // stream), with no host synchronization. set_stream() is a no-op for a
+    // synchronously allocated buffer. The free itself happens when the last
+    // reference to the message is dropped.
+    if (stream_ != nullptr) {
+      data->data.get_deleter().set_stream(stream_);
+    }
   } else {
     RCLCPP_ERROR_STREAM(
       node_.get_logger(), "There was not data with the requested instance id= "
@@ -122,6 +131,11 @@ void CudaBlackboardSubscriber<T>::compatibleCallback(
     node_.get_logger(),
     "The compatible callback was called. This results in a performance loss. This behavior is "
     "probably not intended or a temporal measure");
+  // Construct synchronously even on the stream-aware path: the source ROS
+  // message buffer is owned by the subscription and released right after this
+  // callback returns, so an async host-to-device copy could outlive it. This is
+  // the rare degraded fallback (negotiation not yet established), so the extra
+  // synchronization is acceptable.
   callback_(std::make_shared<T>(*ros_msg_ptr));
 }
 


### PR DESCRIPTION
## What

Adds **opt-in, stream-ordered** allocation/free to `cuda_blackboard` so producers and consumers can stay on their own CUDA streams instead of being serialized by the implicit **device-wide synchronization** that `cudaMalloc` / `cudaFree` perform on every publish/receive.

Everything here is an **additive overload** — existing call sites compile unchanged and keep today's synchronous behavior. Nothing in this PR changes the default path; the user packages (`autoware_cuda_pointcloud_preprocessor`, `autoware_lidar_centerpoint`, `autoware_ptv3`, `autoware_ground_segmentation_cuda`) are migrated to pass their streams in a **follow-up PR**.

## Why

- `cudaMalloc` and `cudaFree` both implicitly synchronize the **whole device**, stalling every stream in the process on each message.
- Producers additionally `cudaStreamSynchronize` after filling a buffer before publishing.
- With stream-ordered allocation (`cudaMallocAsync` / `cudaFreeAsync`) plus CUDA-event handshakes, the produce → consume → free chain can be expressed entirely in stream order, with **no host stall** and no device-wide barrier.

## Roles & responsibilities

- **Publisher stream** is used for `cudaMallocAsync` (producer side) and, inside `publish()`, to record a **ready** event marking "buffer filled". The event handle is stored next to the instance id in the `CudaBlackboard` entry.
- **Subscriber stream** is used to wait on that ready event (so the consumer's reads are ordered after the producer's fill, no host stall), and then — once the user callback returns — to **free** the buffer (`cudaFreeAsync` on the subscriber stream). Because the reads and the free are queued on the same stream, the free is naturally ordered after the reads; no extra events are needed.

`CudaImage` / `CudaPointCloud2` are **unchanged**. The event lives in the blackboard entry (destroyed when the buffer is freed); the free stream is re-targeted through `CudaDeleter::set_stream()`.

> **Multiple intra-process subscribers:** the buffer is freed on the *last* subscriber's stream, so the async free is ordered after that subscriber's reads. If several intra-process CUDA subscribers share one topic and read on different streams, prefer keeping the synchronous path for that topic (don't pass streams) until per-consumer fencing is added.

The producing node owns the publisher stream, which outlives the messages it produces; the subscriber stream must likewise outlive the subscriber.

## Mechanism (sequence diagrams)

Both show the negotiated (zero-copy) path: the publisher registers the buffer in the `CudaBlackboard` singleton and sends only an instance id over the negotiated topic; the subscriber queries the buffer back by id.

### Before

```mermaid
sequenceDiagram
    participant P as Producer node
    participant Pub as CudaBlackboardPublisher
    participant BB as CudaBlackboard (singleton)
    participant Sub as CudaBlackboardSubscriber
    participant C as Consumer node

    P->>P: make_unique(n)
    Note over P: cudaMalloc — blocks the whole device
    P->>P: fill_kernel on stream_
    P->>Pub: publish(msg)
    Pub->>BB: registerData(msg, tickets)
    Pub-->>Sub: publish instance_id (UInt64, negotiated topic)
    Sub->>BB: queryData(instance_id)
    BB-->>Sub: shared_ptr to msg
    Sub->>C: callback(msg)
    C->>C: read_kernel on stream_
    Note over C: no explicit synchronization
    Note over BB: tickets reach 0 / last reference dropped
    BB->>BB: ~CudaPointCloud2 -> cudaFree
    Note over BB: cudaFree blocks the whole device<br/>(incidentally drains stream_ so reads finish)
```

### After

```mermaid
sequenceDiagram
    participant P as Producer node
    participant Pub as CudaBlackboardPublisher
    participant BB as CudaBlackboard (singleton)
    participant Sub as CudaBlackboardSubscriber
    participant C as Consumer node

    P->>P: make_unique(n, pub_stream)
    Note over P: cudaMallocAsync(pub_stream) — no device-wide stall
    P->>P: fill_kernel on pub_stream
    P->>Pub: publish(msg, pub_stream)
    Pub->>Pub: cudaEventRecord(ready, pub_stream)
    Pub->>BB: registerData(msg, tickets, ready)
    Pub-->>Sub: publish instance_id (UInt64, negotiated topic)
    Sub->>BB: queryData(instance_id) -> msg + ready event
    BB-->>Sub: shared_ptr to msg, ready
    Sub->>Sub: cudaStreamWaitEvent(sub_stream, ready)
    Sub->>C: callback(msg)
    C->>C: read_kernel on sub_stream
    Sub->>Sub: set_stream(sub_stream) on the buffer's deleter
    Note over BB: tickets reach 0 / last reference dropped
    BB->>BB: ~wrapper -> cudaEventDestroy(ready)
    BB->>BB: cudaFreeAsync(buffer, sub_stream)
    Note over BB: free queued after the reads on sub_stream,<br/>no host stall
```

## Example usage (new vs. previous)

### Publisher

```cpp
// BEFORE
auto output = std::make_unique<CudaPointCloud2>();
output->data = cuda_blackboard::make_unique<std::uint8_t[]>(n);  // cudaMalloc
fill_kernel<<<grid, block, 0, stream_>>>(output->data.get());
pub_->publish(std::move(output));
// No explicit sync here, yet the fill is ordered before consumers read it: the
// allocation (cudaMalloc) and the buffer's eventual release (cudaFree) inside
// cuda_blackboard each block the *whole device*, which incidentally drains stream_.

// AFTER
auto output = std::make_unique<CudaPointCloud2>();
output->data = cuda_blackboard::make_unique<std::uint8_t[]>(n, stream_);  // cudaMallocAsync, no device-wide stall
fill_kernel<<<grid, block, 0, stream_>>>(output->data.get());
pub_->publish(std::move(output), stream_);  // records a "ready" event consumers wait on
```

### Subscriber

```cpp
// BEFORE
sub_ = std::make_unique<CudaBlackboardSubscriber<CudaPointCloud2>>(
  *this, "~/input/pointcloud",
  std::bind(&Node::callback, this, std::placeholders::_1));

void Node::callback(const CudaPointCloud2::ConstSharedPtr & msg) {
  read_kernel<<<grid, block, 0, stream_>>>(msg->data.get());
  // No explicit sync, yet the buffer stays alive until the read finishes: its
  // cudaFree inside cuda_blackboard blocks the whole device when the buffer is
  // released, which incidentally drains stream_ first.
}

// AFTER
sub_ = std::make_unique<CudaBlackboardSubscriber<CudaPointCloud2>>(
  *this, "~/input/pointcloud",
  std::bind(&Node::callback, this, std::placeholders::_1),
  stream_);  // stream must outlive the subscriber

void Node::callback(const CudaPointCloud2::ConstSharedPtr & msg) {
  // the subscriber already waited on the producer's ready event on stream_
  read_kernel<<<grid, block, 0, stream_>>>(msg->data.get());
  // no host sync: when the callback returns, the subscriber frees the buffer
  // with cudaFreeAsync on stream_, ordered after these reads
}
```

The old no-stream `make_unique(n)`, `publish(msg)`, and subscriber constructors are unchanged and continue to use the device-wide-blocking `cudaMalloc` / `cudaFree`.

## Changes

| File | Change |
|---|---|
| `cuda_unique_ptr.hpp` | `CudaDeleter` optionally frees with `cudaFreeAsync` and exposes `set_stream()` to re-target the free stream (mutable, so it works through a `shared_ptr<const T>`). New `make_unique(n, stream)` / `make_unique(stream)` use `cudaMallocAsync`. Deleter **type unchanged**, so `CudaUniquePtr<T>` / `CudaPointCloud2::data` are source-compatible. |
| `cuda_blackboard.{hpp,cpp}` | `CudaBlackboardDataWrapper` carries the publisher's ready event (destroyed with the entry). `registerData(…, ready_event)` and `queryData(id, &ready_event)` thread it through; `queryData` now returns an **aliasing** `shared_ptr` so the entry (and its event) outlive every subscriber's queued wait. |
| `cuda_blackboard_publisher.{hpp,cpp}` | Add `publish(msg, stream)`: records the ready event on the publisher stream and registers it; stream-safe ROS-compat conversion. |
| `cuda_blackboard_subscriber.{hpp,cpp}` | Add `(…, callback, stream)` constructor; wait on the ready event before the callback, then re-target the buffer's free to the subscriber stream. |
| `cuda_pointcloud2.*`, `cuda_image.*` | **Unchanged.** |

## Compatibility / requirements

- Fully source-backwards-compatible (additive overloads only). ABI grows slightly because the deleter is no longer empty; irrelevant under colcon since everything rebuilds from headers.
- Requires CUDA ≥ 11.2 with stream-ordered memory-pool support (`cudaDevAttrMemoryPoolsSupported`). Validated against CUDA 12.x.

## Testing

- `colcon build` of `cuda_blackboard` (incl. the example publisher/subscriber nodes, which use the **old** API) — passes.
- Unchanged rebuild of `autoware_lidar_centerpoint` against the new headers — passes (backwards-compat check).
- Suggested follow-up before merge of the migration PR: `compute-sanitizer --tool memcheck/synccheck` on a preprocessor → centerpoint pipeline, and an Nsight Systems trace confirming the device-wide stalls are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
