### PR TITLE
ci: update GitHub Actions runner from ubuntu-22.04 to ubuntu-24.04

### DIFF
--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -25,7 +25,7 @@ jobs:
   build-and-test-differential:
     needs: require-label
     if: ${{ needs.require-label.outputs.result == 'true' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: ${{ matrix.container }}
     strategy:
       fail-fast: false

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   build-and-test:
     if: ${{ github.event_name != 'push' || github.ref_name == github.event.repository.default_branch }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: ${{ matrix.container }}
     strategy:
       fail-fast: false

--- a/.github/workflows/cancel-previous-workflows.yaml
+++ b/.github/workflows/cancel-previous-workflows.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   cancel-previous-workflows:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Cancel previous runs
         uses: styfle/cancel-workflow-action@0.12.1

--- a/.github/workflows/cppcheck-differential.yaml
+++ b/.github/workflows/cppcheck-differential.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   cppcheck-differential:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Set PR fetch depth

--- a/.github/workflows/cppcheck-weekly.yaml
+++ b/.github/workflows/cppcheck-weekly.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   cppcheck-weekly:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code

--- a/.github/workflows/pre-commit-optional.yaml
+++ b/.github/workflows/pre-commit-optional.yaml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   pre-commit-optional:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   pre-commit:
     if: ${{ github.event.repository.private }} # Use pre-commit.ci for public repositories
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate token
         id: generate-token

--- a/.github/workflows/spell-check-differential.yaml
+++ b/.github/workflows/spell-check-differential.yaml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   spell-check-differential:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Update GitHub Actions runner from `ubuntu-22.04` to `ubuntu-24.04`

## Notes
- `ubuntu-22.04-m` and `ubuntu-22.04-arm` are intentionally unchanged

## Test plan
- [ ] CI workflows pass on this PR
